### PR TITLE
fix(dropdown): remove attribute to add the carrot to the trigger #26

### DIFF
--- a/src/auro-combobox.js
+++ b/src/auro-combobox.js
@@ -334,7 +334,6 @@ class AuroCombobox extends LitElement {
           for="dropdownMenu"
           bordered
           rounded
-          chevron
           ?disabled="${this.disabled}"
           ?error="${this.error}"
           disableEventShow>


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Fixes:** #26 

## Summary:

Removes the `chevron` attribute from auro-dropdown so that the carrot on the right of the trigger is not shown per the Figma document.

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**
-- Auro Design System Team
